### PR TITLE
make composite constraint to allow one repo many projects

### DIFF
--- a/migrations/2024-10-30-171726_make_repo_urls_and_slugs_not_unique_and_add_constraint/down.sql
+++ b/migrations/2024-10-30-171726_make_repo_urls_and_slugs_not_unique_and_add_constraint/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE repositories DROP CONSTRAINT IF EXISTS unique_url_slug_project_id;
+
+ALTER TABLE repositories ADD CONSTRAINT repositories_slug_key UNIQUE (slug);
+ALTER TABLE repositories ADD CONSTRAINT repositories_url_key UNIQUE (url);

--- a/migrations/2024-10-30-171726_make_repo_urls_and_slugs_not_unique_and_add_constraint/up.sql
+++ b/migrations/2024-10-30-171726_make_repo_urls_and_slugs_not_unique_and_add_constraint/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE repositories DROP CONSTRAINT IF EXISTS repositories_slug_key;
+ALTER TABLE repositories DROP CONSTRAINT IF EXISTS repositories_url_key;
+
+ALTER TABLE repositories ADD CONSTRAINT unique_url_slug_project_id UNIQUE (url, slug, project_id);


### PR DESCRIPTION
Remove uniqueness unique slug and unique url constraint, instead create a constraint requiring a unique (slug, url, project_id ) for a repository. This will allow us to link a repository and it's issues to multiple projects.