### PR TITLE
[feat] add new query arg certified_or_labels (bool) in /issues

### DIFF
--- a/src/api/issues/handlers.rs
+++ b/src/api/issues/handlers.rs
@@ -68,6 +68,7 @@ pub async fn leaderboard(
             issue_closed_at_min: params.start_date,
             issue_closed_at_max: params.close_date,
             rewards: params.rewards,
+            certified_or_labels: Some(false),
         },
         PaginationParams {
             limit: i64::MAX,

--- a/src/api/issues/models.rs
+++ b/src/api/issues/models.rs
@@ -83,6 +83,7 @@ pub struct QueryParams {
     pub issue_closed_at_min: Option<DateTime<Utc>>,
     pub issue_closed_at_max: Option<DateTime<Utc>>,
     pub rewards: Option<bool>,
+    pub certified_or_labels: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
- If `certified_or_labels` is true in `/issues`, it will use an `OR` when filtering `certified` and `labels` (if both are present).